### PR TITLE
Use DeleteAllOf to clear all predefined Tinkerbell objects

### DIFF
--- a/onboarding-manager/internal/tinkerbell/bootstrap.go
+++ b/onboarding-manager/internal/tinkerbell/bootstrap.go
@@ -15,7 +15,7 @@ const (
 func Bootstrap() error {
 	zlog.Info().Msg("Bootstrapping Tinkerbell state")
 
-	if err := clearAllTinkResources(); err != nil {
+	if err := DeletePredefinedTinkerbellResources(); err != nil {
 		return err
 	}
 
@@ -43,26 +43,4 @@ func createTemplates() error {
 
 func createDummyHardware() error {
 	return CreateHardwareIfNotExists(env.K8sNamespace, DummyHardwareName)
-}
-
-func clearAllTinkResources() error {
-	zlog.Info().Msg("Clearing dummy Tinkerbell hardware")
-	if err := DeleteHardware(env.K8sNamespace, DummyHardwareName); err != nil {
-		return err
-	}
-
-	zlog.Info().Msg("Clearing all existing Tinkerbell templates")
-	allTemplates, err := ListTemplates()
-	if err != nil {
-		return err
-	}
-
-	for _, tmpl := range allTemplates {
-		zlog.Info().Msgf("Deleting Tinkerbell template %q", tmpl.Name)
-		if delErr := DeleteTemplate(tmpl.Name, tmpl.Namespace); delErr != nil {
-			return delErr
-		}
-	}
-
-	return nil
 }

--- a/onboarding-manager/internal/tinkerbell/client.go
+++ b/onboarding-manager/internal/tinkerbell/client.go
@@ -149,7 +149,7 @@ func deleteAllK8sResourcesOfKind(namespace string, kinds []client.Object) error 
 	}
 
 	for _, kind := range kinds {
-		if err = kubeClient.DeleteAllOf(ctx, kind, client.InNamespace(namespace); err != nil {
+		if err = kubeClient.DeleteAllOf(ctx, kind, client.InNamespace(namespace)); err != nil {
 			zlog.InfraSec().InfraErr(err).Msg("")
 			return inv_errors.Errorf("Failed to delete Tinkerbell template")
 		}

--- a/onboarding-manager/internal/tinkerbell/client.go
+++ b/onboarding-manager/internal/tinkerbell/client.go
@@ -72,24 +72,6 @@ func NewWorkflow(name, ns, hardwareRef, templateRef string, hardwareMap map[stri
 	return wf
 }
 
-func ListTemplates() ([]tinkv1alpha1.Template, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultK8sClientTimeout)
-	defer cancel()
-
-	kubeClient, err := K8sClientFactory()
-	if err != nil {
-		return nil, err
-	}
-
-	tmplList := &tinkv1alpha1.TemplateList{}
-	err = kubeClient.List(ctx, tmplList, client.InNamespace(env.K8sNamespace))
-	if err != nil {
-		return nil, err
-	}
-
-	return tmplList.Items, nil
-}
-
 func CreateTemplate(k8sNamespace, name string, rawTemplateData []byte) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultK8sClientTimeout)
 	defer cancel()
@@ -157,65 +139,31 @@ func CreateHardwareIfNotExists(k8sNamespace, hwName string) error {
 	return nil
 }
 
-func DeleteHardware(k8sNamespace, hwName string) error {
+func deleteAllK8sResourcesOfKind(namespace string, kinds []client.Object) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultK8sClientTimeout)
 	defer cancel()
-
-	zlog.Debug().Msgf("Deleting Tinkerbell Hardware %q", hwName)
 
 	kubeClient, err := K8sClientFactory()
 	if err != nil {
 		return err
 	}
 
-	hw := &tinkv1alpha1.Hardware{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Hardware",
-			APIVersion: "tinkerbell.org/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      hwName,
-			Namespace: k8sNamespace,
-		},
-	}
-
-	if err = kubeClient.Delete(ctx, hw); err != nil && !errors.IsNotFound(err) {
-		zlog.InfraSec().InfraErr(err).Msg("")
-		zlog.Debug().Msgf("Failed to delete Tink hardware resource %q", hwName)
-		return inv_errors.Errorf("Failed to delete Tink hardware resource")
+	for _, kind := range kinds {
+		if err = kubeClient.DeleteAllOf(ctx, kind, client.InNamespace(namespace); err != nil {
+			zlog.InfraSec().InfraErr(err).Msg("")
+			return inv_errors.Errorf("Failed to delete Tinkerbell template")
+		}
 	}
 
 	return nil
 }
 
-func DeleteTemplate(name, namespace string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultK8sClientTimeout)
-	defer cancel()
-
-	kubeClient, err := K8sClientFactory()
-	if err != nil {
-		return err
-	}
-
-	zlog.Debug().Msgf("Deleting prod template %s in namespace %s", name, namespace)
-
-	template := &tinkv1alpha1.Template{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Template",
-			APIVersion: "tinkerbell.org/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-
-	if err = kubeClient.Delete(ctx, template); err != nil && !errors.IsNotFound(err) {
-		zlog.InfraSec().InfraErr(err).Msg("")
-		return inv_errors.Errorf("Failed to delete Tinkerbell template")
-	}
-
-	return nil
+func DeletePredefinedTinkerbellResources() error {
+	zlog.Debug().Msgf("Deleting all Tinkerbell Template and Hardware objects in namespace %s", env.K8sNamespace)
+	return deleteAllK8sResourcesOfKind(env.K8sNamespace, []client.Object{
+		&tinkv1alpha1.Template{},
+		&tinkv1alpha1.Hardware{},
+	})
 }
 
 func CreateWorkflowIfNotExists(ctx context.Context, k8sCli client.Client, workflow *tinkv1alpha1.Workflow) error {

--- a/onboarding-manager/internal/tinkerbell/client_test.go
+++ b/onboarding-manager/internal/tinkerbell/client_test.go
@@ -100,40 +100,6 @@ func TestNewWorkflow(t *testing.T) {
 	}
 }
 
-func TestDeleteHardwareForHostIfExist(t *testing.T) {
-	currK8sClientFactory := K8sClientFactory
-	defer func() {
-		K8sClientFactory = currK8sClientFactory
-	}()
-	K8sClientFactory = om_testing.K8sCliMockFactory(false, false, false)
-	type args struct {
-		ctx          context.Context
-		k8sNamespace string
-		name         string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "TestDeleteHardwareForHostIfExist_KubernetesEnvironment",
-			args: args{
-				ctx: context.Background(),
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := DeleteHardware(tt.args.k8sNamespace,
-				tt.args.name); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteHardwareForHostIfExist() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
 func TestCreateHardwareIfNotExists(t *testing.T) {
 	type args struct {
 		ctx          context.Context
@@ -193,31 +159,6 @@ func TestCreateHardwareIfNotExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := CreateHardwareIfNotExists(tt.args.k8sNamespace, "test"); (err != nil) != tt.wantErr {
 				t.Errorf("CreateHardwareIfNotExists() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestDeleteHardwareForHostIfExist_ErrorScenario(t *testing.T) {
-	type args struct {
-		k8sNamespace string
-		name         string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name:    "Kubeclient error",
-			args:    args{},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := DeleteHardware(tt.args.k8sNamespace, tt.args.name); (err != nil) != tt.wantErr {
-				t.Errorf("DeleteHardwareForHostIfExist() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

This PR improves how OM clears the pre-defined Tinkerbell resources at startup by leveraging built-in `DeleteAllOf`. 

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested on Coder.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
