### PR TITLE
fix: Don't include SSHD config for standalone nodes

### DIFF
--- a/onboarding-manager/pkg/cloudinit/99_infra.cfg
+++ b/onboarding-manager/pkg/cloudinit/99_infra.cfg
@@ -179,7 +179,6 @@ write_files:
     permissions: '0600'
     content: |
       {{ .CLIENT_SECRET }}
-  {{- end }}
 
   - path: /etc/ssh/sshd_config
     content: |
@@ -201,6 +200,7 @@ write_files:
       {{- else }}
       Subsystem sftp /usr/lib/openssh/sftp-server
       {{- end }}
+   {{- end }}
 runcmd:
   {{- if .WITH_PRESERVE_IP }}
   - bash /opt/intel_edge_node/staticip.sh

--- a/onboarding-manager/pkg/cloudinit/testout/expected-installer-13.cfg
+++ b/onboarding-manager/pkg/cloudinit/testout/expected-installer-13.cfg
@@ -36,23 +36,6 @@ write_files:
               efibootmgr -b "$boot_part_number" -a
           fi
       done < <(efibootmgr | grep "Boot" | grep -i -v -E "BootCurrent|BootOrder" | awk '{print $1}' | cut -c 5-9)
-
-  - path: /etc/ssh/sshd_config
-    content: |
-      PermitRootLogin no
-      PasswordAuthentication no
-      PubkeyAuthentication yes
-      AuthenticationMethods publickey
-      KbdInteractiveAuthentication no
-      GSSAPIAuthentication no
-      HostbasedAuthentication no
-      HostKeyAlgorithms ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com
-      PubkeyAcceptedAlgorithms ssh-ed25519,ecdsa-sha2-nistp521
-      KexAlgorithms ecdh-sha2-nistp384,ecdh-sha2-nistp521
-      MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
-      Ciphers aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr
-      UsePAM yes
-      Subsystem sftp /usr/libexec/sftp-server
 runcmd:
   - |
     grep -qF "http_proxy" /etc/environment || echo http_proxy=http-proxy.test >> /etc/environment

--- a/onboarding-manager/pkg/cloudinit/testout/expected-installer-14.cfg
+++ b/onboarding-manager/pkg/cloudinit/testout/expected-installer-14.cfg
@@ -45,23 +45,6 @@ write_files:
               efibootmgr -b "$boot_part_number" -a
           fi
       done < <(efibootmgr | grep "Boot" | grep -i -v -E "BootCurrent|BootOrder" | awk '{print $1}' | cut -c 5-9)
-
-  - path: /etc/ssh/sshd_config
-    content: |
-      PermitRootLogin no
-      PasswordAuthentication no
-      PubkeyAuthentication yes
-      AuthenticationMethods publickey
-      KbdInteractiveAuthentication no
-      GSSAPIAuthentication no
-      HostbasedAuthentication no
-      HostKeyAlgorithms ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com
-      PubkeyAcceptedAlgorithms ssh-ed25519,ecdsa-sha2-nistp521
-      KexAlgorithms ecdh-sha2-nistp384,ecdh-sha2-nistp521
-      MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
-      Ciphers aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr
-      UsePAM yes
-      Subsystem sftp /usr/libexec/sftp-server
 runcmd:
   - |
     grep -qF "http_proxy" /etc/environment || echo http_proxy=http-proxy.test >> /etc/environment


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

The USB installer doesn't provide any additional SSH configuration. One implication is that the USB-based EMT-S allows for password-based SSH login. This PR removes restrictive SSH config to achieve feature parity with USB-based EMT-S.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
