### PR TITLE
Add support for configurable memory for health check service

### DIFF
--- a/dkam/pkg/config/config.go
+++ b/dkam/pkg/config/config.go
@@ -47,6 +47,7 @@ type InfraConfig struct {
 	RegistryURL             string `mapstructure:"orchRegistry"`
 	FileServerURL           string `mapstructure:"orchFileServer"`
 	RSType                  string `mapstructure:"rsType"`
+	MaxAgentMemory          string `mapstructure:"maxAgentMemory"`
 
 	ProvisioningService string `mapstructure:"provisioningSvc"`
 	// ProvisioningServerURL full URL to the provisioning server, including prefixes and subpaths

--- a/dkam/pkg/curation/curation.go
+++ b/dkam/pkg/curation/curation.go
@@ -161,6 +161,7 @@ func GetCommonInfraTemplateVariables(infraConfig config.InfraConfig, osType osv1
 		"ORCH_PLATFORM_MANAGEABILITY_HOST": strings.Split(infraConfig.ManageabilityURL, ":")[0],
 		"ORCH_PLATFORM_MANAGEABILITY_PORT": strings.Split(infraConfig.ManageabilityURL, ":")[1],
 		"RPS_ADDRESS":                      strings.Split(infraConfig.RPSAddress, ":")[0],
+		"MAX_AGENT_MEMORY":                 infraConfig.MaxAgentMemory,
 
 		"EN_HTTP_PROXY":  infraConfig.ENProxyHTTP,
 		"EN_HTTPS_PROXY": infraConfig.ENProxyHTTPS,

--- a/onboarding-manager/pkg/cloudinit/99_infra.cfg
+++ b/onboarding-manager/pkg/cloudinit/99_infra.cfg
@@ -131,6 +131,7 @@ write_files:
       RELEASE_FQDN={{ .RELEASE_FQDN }}
       RS_TYPE={{ .RS_TYPE }}
       RSTYPE={{ .RS_TYPE }}
+      MAX_AGENT_MEMORY= {{ .MAX_AGENT_MEMORY }}
   {{- if not .IS_MICROVISOR }}
   - path: /etc/intel_edge_node/agent_versions
     content: |

--- a/onboarding-manager/pkg/platformbundle/ubuntu-22.04/Installer
+++ b/onboarding-manager/pkg/platformbundle/ubuntu-22.04/Installer
@@ -418,6 +418,13 @@ install_other_agents() {
         platform-telemetry-agent="$PLATFORM_TELEMETRY_AGENT_VERSION" \
         platform-manageability-agent="$PLATFORM_MANAGEABILITY_AGENT_VERSION"
 
+      # Update maximum allowed memory for agents if provided
+      if [ -n "$MAX_AGENT_MEMORY" ]; then
+        systemctl stop platform-observability-health-check.service
+        sed -i "s/MemoryMax=.*/MemoryMax=$MAX_AGENT_MEMORY/g" /lib/systemd/system/platform-observability-health-check.service
+        systemctl start platform-observability-health-check.service
+      fi
+
       # Remove docker. trtl and inbm-telemetry checks from INBM configuration file
       remove_lines_from_sotaSW /etc/intel_manageability.conf docker trtl inbm-telemetry
       echo "install_other_agents done" | tee -a "$SCRIPT_DIR"/$STATUS_FILENAME


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### Description

Updates the cloud-init to allow for configuration of the MemoryMax setting in the platform-observability-health-check service on the edge node to a non-default value.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
