### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-dkam.yaml
+++ b/.github/workflows/post-merge-dkam.yaml
@@ -12,6 +12,8 @@ on:
       - release-*
     paths:
       - "dkam/**"
+    tags:
+      - '*'
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge-onboarding-manager.yaml
+++ b/.github/workflows/post-merge-onboarding-manager.yaml
@@ -12,6 +12,8 @@ on:
       - release-*
     paths:
       - "onboarding-manager/**"
+    tags:
+      - '*'
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge-pxe-server.yaml
+++ b/.github/workflows/post-merge-pxe-server.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "pxe-server/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-tink-worker.yaml
+++ b/.github/workflows/post-merge-tink-worker.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "tink-worker/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-tinker-actions.yaml
+++ b/.github/workflows/post-merge-tinker-actions.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "tinker-actions/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to add support for triggering workflows on tag creation, in addition to the existing branch and path-based triggers. This ensures that workflows can be executed when a tag matching any pattern is pushed.

Workflow trigger enhancements:

* Added a `tags` trigger (matching any tag: `'*'`) to the following workflow files, allowing them to run on tag creation:
  - `.github/workflows/post-merge-dkam.yaml`
  - `.github/workflows/post-merge-onboarding-manager.yaml`
  - `.github/workflows/post-merge-pxe-server.yaml`
  - `.github/workflows/post-merge-tink-worker.yaml`
  - `.github/workflows/post-merge-tinker-actions.yaml`