### PR TITLE
Remove trigger on tag from post merge workflows

### DIFF
--- a/.github/workflows/post-merge-dkam.yaml
+++ b/.github/workflows/post-merge-dkam.yaml
@@ -12,8 +12,6 @@ on:
       - release-*
     paths:
       - "dkam/**"
-    tags:
-      - '*'
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge-onboarding-manager.yaml
+++ b/.github/workflows/post-merge-onboarding-manager.yaml
@@ -12,8 +12,6 @@ on:
       - release-*
     paths:
       - "onboarding-manager/**"
-    tags:
-      - '*'
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge-pxe-server.yaml
+++ b/.github/workflows/post-merge-pxe-server.yaml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "pxe-server/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-tink-worker.yaml
+++ b/.github/workflows/post-merge-tink-worker.yaml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "tink-worker/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-tinker-actions.yaml
+++ b/.github/workflows/post-merge-tinker-actions.yaml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "tinker-actions/**"
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files by removing the `tags` trigger from their `on` sections. This change ensures that these workflows are no longer triggered by tag events, streamlining when and how they run.

**Workflow trigger updates:**

* Removed the `tags` trigger from the following workflow files to prevent them from running on tag events:
  - `.github/workflows/post-merge-dkam.yaml`
  - `.github/workflows/post-merge-onboarding-manager.yaml`
  - `.github/workflows/post-merge-pxe-server.yaml`
  - `.github/workflows/post-merge-tink-worker.yaml`
  - `.github/workflows/post-merge-tinker-actions.yaml`